### PR TITLE
Update favicon.ico size to fix below error

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,7 +4,7 @@
   "icons": [
     {
       "src": "favicon.ico",
-      "sizes": "192x192",
+      "sizes": "64x64",
       "type": "image/png"
     }
   ],


### PR DESCRIPTION
Error while trying to use the following icon from the Manifest: https://umitao.github.io/cyf-hotel-react/favicon.ico (Resource size is not correct - typo in the Manifest?)